### PR TITLE
Auto dispatch added to CTC && modules added to Main Menu

### DIFF
--- a/CTC/src/ctc/controller/CentralTrafficControlController.java
+++ b/CTC/src/ctc/controller/CentralTrafficControlController.java
@@ -19,7 +19,7 @@ import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.control.cell.TextFieldTableCell;
 import mainmenu.Clock;
 
-public class MainController {
+public class CentralTrafficControlController {
 
   private CentralTrafficControl ctc = CentralTrafficControl.getInstance();
   private Clock clock = Clock.getInstance();
@@ -85,6 +85,19 @@ public class MainController {
    */
   public void initialize() {
     connect();
+  }
+
+  /**
+   * Main run function to be called the Runner. This will handle the operations
+   * each tick of the clock.
+   */
+  public void run() {
+    ctc.updateDisplayTime();
+    dispatch();
+  }
+
+  public CentralTrafficControl getCtc() {
+    return ctc;
   }
 
   private void connect() {
@@ -445,6 +458,7 @@ public class MainController {
 
     // create train
     ctc.addTrain(train);
+//    ctc.getTrainQueueTable().addAll(train);
   }
 
   private void deleteTrainFromQueue() {
@@ -457,7 +471,6 @@ public class MainController {
     }
 
     trainQueueTable.setItems(ctc.getTrainQueueTable());
-    // selectedScheduleTable.setItems(FXCollections.observableArrayList());
   }
 
   private void dispatchTrain() {
@@ -482,6 +495,31 @@ public class MainController {
   private void setSuggestedSpeed(){}
 
   private void setAuthority(){}
+
+  private void dispatch() {
+
+    ObservableList<TrainListItem> trains = ctc.getTrainQueueTable();
+    for (int i = 0; i < trains.size(); i++) {
+      if (trains.get(i).getDeparture().equals(clock.getFormattedTime())
+          && !ctc.getDispatchTable().contains(trains.get(i))) {
+        autoDispatchTrain(i);
+      }
+    }
+  }
+
+  private void autoDispatchTrain(int index) {
+
+    TrainListItem train = ctc.getTrainQueueTable().get(index);
+
+    // remove selected train from queue
+    ctc.getTrainQueueTable().remove(index);
+    ctc.getDispatchTable().add(train);
+
+    dispatchTable.setItems(ctc.getDispatchTable());
+    if (ctc.getTrainQueueTable().size() == 0) {
+      selectedScheduleTable.setItems(FXCollections.observableArrayList());
+    }
+  }
 
   private void changeMode(
       String mode,

--- a/CTC/src/ctc/model/CentralTrafficControl.java
+++ b/CTC/src/ctc/model/CentralTrafficControl.java
@@ -1,13 +1,11 @@
 package ctc.model;
 
-import java.util.ArrayList;
-import javafx.beans.property.IntegerProperty;
-import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import mainmenu.Clock;
+
 
 public class CentralTrafficControl {
 
@@ -23,6 +21,7 @@ public class CentralTrafficControl {
   private long exactTime;
   private StringProperty displayTime = new SimpleStringProperty();
   private String throughput = "17.4 passenger/s";
+
 
   /**
    * Base constructor can only be access via the getInstance() method.
@@ -49,15 +48,7 @@ public class CentralTrafficControl {
     updateDisplayTime();
   }
 
-  /**
-   * Main run function to be called the Runner. This will handle the operations
-   * each tick of the clock.
-   */
-  public void run() {
-    updateDisplayTime();
-  }
-
-  private void updateDisplayTime() {
+  public void updateDisplayTime() {
     displayTime.setValue(clock.getFormattedTime());
   }
 

--- a/CTC/src/ctc/view/CentralTrafficControlUserInterface.java
+++ b/CTC/src/ctc/view/CentralTrafficControlUserInterface.java
@@ -1,5 +1,6 @@
 package ctc.view;
 
+import ctc.controller.CentralTrafficControlController;
 import java.io.IOException;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
@@ -8,20 +9,44 @@ import javafx.stage.Stage;
 
 public class CentralTrafficControlUserInterface {
 
-  /**
-   * Main method to  be called from the Main Menu to open window.
-   * @param args String[] needed to make Java happy
-   */
-  public static void main(String[] args) {
+  private static CentralTrafficControlUserInterface instance = null;
+  private CentralTrafficControlController controller;
+  private Parent root;
+
+  private CentralTrafficControlUserInterface() {
+
+    FXMLLoader loader = new FXMLLoader(getClass().getResource("ctc.fxml"));
 
     try {
-      Parent root1 = (Parent) FXMLLoader.load(
-          CentralTrafficControlUserInterface.class.getResource("ctc.fxml"));
-      Stage stage = new Stage();
-      stage.setScene(new Scene(root1));
-      stage.show();
+      this.root = loader.load();
+      this.controller = loader.getController();
     } catch (IOException e) {
       System.out.println(e);
     }
+  }
+
+  /**
+   * This is the logic to maintain a single instance of a CTC UI object.
+   * @return the single instance of the CTC UI
+   */
+  public static CentralTrafficControlUserInterface getInstance() {
+    if (instance == null) {
+      instance = new CentralTrafficControlUserInterface();
+    }
+    return instance;
+  }
+
+  /**
+   * Called by Main Menu to load the window for the CTC UI.
+   */
+  public void load() {
+
+    Stage stage = new Stage();
+    stage.setScene(new Scene(root));
+    stage.show();
+  }
+
+  public CentralTrafficControlController getController() {
+    return controller;
   }
 }

--- a/CTC/src/ctc/view/ctc.fxml
+++ b/CTC/src/ctc/view/ctc.fxml
@@ -20,7 +20,7 @@
 <?import javafx.scene.shape.Circle?>
 <?import javafx.scene.text.Font?>
 
-<SplitPane dividerPositions="0.1806020066889632" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" orientation="VERTICAL" prefHeight="600.0" prefWidth="1400.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="ctc.controller.MainController">
+<SplitPane dividerPositions="0.1806020066889632" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" orientation="VERTICAL" prefHeight="600.0" prefWidth="1400.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="ctc.controller.CentralTrafficControlController">
   <items>
     <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="50.0" prefWidth="798.0">
          <children>

--- a/MBO/src/mbo/view/MovingBlockOverlayController.java
+++ b/MBO/src/mbo/view/MovingBlockOverlayController.java
@@ -22,7 +22,7 @@ import java.util.ResourceBundle;
 import java.io.*;
 
 
-public class Controller implements Initializable{
+public class MovingBlockOverlayController implements Initializable {
 
   String name;
 

--- a/MBO/src/mbo/view/MovingBlockOverlayUserInterface.java
+++ b/MBO/src/mbo/view/MovingBlockOverlayUserInterface.java
@@ -8,20 +8,46 @@ import javafx.stage.Stage;
 
 public class MovingBlockOverlayUserInterface {
 
-  /**
-   * Main method to be called from the Main Menu.
-   * @param args necessary String array because Java.
-   * @throws IOException for IO problems!
-   */
-  public static void main(String[] args) throws IOException {
+  private static MovingBlockOverlayUserInterface instance = null;
+  private MovingBlockOverlayController controller;
+  private Parent root;
+
+  private MovingBlockOverlayUserInterface() {
+
+    FXMLLoader loader = new FXMLLoader(getClass().getResource("mbo.fxml"));
+
     try {
-      Parent root1 = (Parent) FXMLLoader.load(
-          MovingBlockOverlayUserInterface.class.getResource("mbo.fxml"));
-      Stage stage = new Stage();
-      stage.setScene(new Scene(root1));
-      stage.show();
+      this.root = loader.load();
+      this.controller = loader.getController();
     } catch (IOException e) {
       System.out.println(e);
     }
+  }
+
+  /**
+   * (mlp)
+   * This is the logic to maintain a single instance of a MBO UI object.
+   * @return the single instance of the MBO UI
+   */
+  public static MovingBlockOverlayUserInterface getInstance() {
+    if (instance == null) {
+      instance = new MovingBlockOverlayUserInterface();
+    }
+    return instance;
+  }
+
+  /**
+   * (mlp)
+   * Called by Main Menu to load the window for the CTC UI.
+   */
+  public void load() {
+
+    Stage stage = new Stage();
+    stage.setScene(new Scene(root));
+    stage.show();
+  }
+
+  public MovingBlockOverlayController getController() {
+    return controller;
   }
 }

--- a/MBO/src/mbo/view/mbo.fxml
+++ b/MBO/src/mbo/view/mbo.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 
-<SplitPane dividerPositions="0.1158" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="969.0" minWidth="938.0" orientation="VERTICAL" prefHeight="969.0" prefWidth="938.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="mbo.view.Controller">
+<SplitPane dividerPositions="0.1158" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="969.0" minWidth="938.0" orientation="VERTICAL" prefHeight="969.0" prefWidth="938.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="mbo.view.MovingBlockOverlayController">
    <items>
       <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="211.0" prefWidth="1322.0">
          <children>

--- a/MainMenu/src/mainmenu/Runner.java
+++ b/MainMenu/src/mainmenu/Runner.java
@@ -1,7 +1,9 @@
 package mainmenu;
 
-import ctc.model.CentralTrafficControl;
+import ctc.controller.CentralTrafficControlController;
 
+import ctc.model.CentralTrafficControl;
+import ctc.view.CentralTrafficControlUserInterface;
 import javafx.animation.Animation;
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
@@ -17,6 +19,8 @@ import javafx.util.Duration;
 public class Runner extends Application {
 
   // create instances of modules
+  private CentralTrafficControlController ctcc =
+      CentralTrafficControlUserInterface.getInstance().getController();
   private CentralTrafficControl ctc = CentralTrafficControl.getInstance();
   private Clock clk = Clock.getInstance();
 
@@ -35,7 +39,7 @@ public class Runner extends Application {
                 // TODO: add other module run() functions inside this event handler
                 if (ctc.isActive()) {
                   clk.tick();
-                  ctc.run();
+                  ctcc.run();
                 }
               }
             }

--- a/MainMenu/src/mainmenu/view/MainMenuController.java
+++ b/MainMenu/src/mainmenu/view/MainMenuController.java
@@ -17,20 +17,16 @@ import trackmodel.view.TrackModelUserInterface;
  */
 public class MainMenuController implements Initializable {
 
+  private CentralTrafficControlUserInterface ctcui =
+      CentralTrafficControlUserInterface.getInstance();
 
-  @FXML
-  private ChoiceBox<String> trackControllerChoiceBox = new ChoiceBox<>();
-  @FXML
-  private ChoiceBox<String> trainControllerChoiceBox = new ChoiceBox<>();
-  @FXML
-  private ChoiceBox<String> trainModelChoiceBox = new ChoiceBox<>();
+  @FXML private ChoiceBox<String> trackControllerChoiceBox = new ChoiceBox<>();
+  @FXML private ChoiceBox<String> trainControllerChoiceBox = new ChoiceBox<>();
+  @FXML private ChoiceBox<String> trainModelChoiceBox = new ChoiceBox<>();
   
-  @FXML
-  private Button trackControllerButton;
-  @FXML
-  private Button trainControllerButton;
-  @FXML
-  private Button trainModelButton;
+  @FXML private Button trackControllerButton;
+  @FXML private Button trainControllerButton;
+  @FXML private Button trainModelButton;
 
   @Override
   public void initialize(URL location, ResourceBundle resources) {
@@ -53,7 +49,7 @@ public class MainMenuController implements Initializable {
    */
   public void openCentralTrafficControl(ActionEvent event) {
     try {
-      CentralTrafficControlUserInterface.main(new String[0]);
+      ctcui.load();
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/MainMenu/src/mainmenu/view/MainMenuController.java
+++ b/MainMenu/src/mainmenu/view/MainMenuController.java
@@ -20,6 +20,12 @@ public class MainMenuController implements Initializable {
   private CentralTrafficControlUserInterface ctcui =
       CentralTrafficControlUserInterface.getInstance();
 
+  private MovingBlockOverlayUserInterface mboui =
+      MovingBlockOverlayUserInterface.getInstance();
+
+  private TrackModelUserInterface tmui =
+      TrackModelUserInterface.getInstance();
+
   @FXML private ChoiceBox<String> trackControllerChoiceBox = new ChoiceBox<>();
   @FXML private ChoiceBox<String> trainControllerChoiceBox = new ChoiceBox<>();
   @FXML private ChoiceBox<String> trainModelChoiceBox = new ChoiceBox<>();
@@ -61,7 +67,7 @@ public class MainMenuController implements Initializable {
    */
   public void openMovingBlockOverlay(ActionEvent event) {
     try {
-      MovingBlockOverlayUserInterface.main(new String[0]);
+      mboui.load();
     } catch (Exception e) {
       e.printStackTrace();
     }
@@ -73,7 +79,7 @@ public class MainMenuController implements Initializable {
    */
   public void openTrackModel(ActionEvent event) {
     try {
-      TrackModelUserInterface.main(new String[0]);
+      tmui.load();
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/TrackModel/src/trackmodel/controller/TrackModelController.java
+++ b/TrackModel/src/trackmodel/controller/TrackModelController.java
@@ -23,7 +23,7 @@ import javafx.stage.Stage;
 
 import trackmodel.model.Block;
 
-public class Controller {
+public class TrackModelController {
   //DROPDOWNS
   @FXML
   private ChoiceBox trackSelection;

--- a/TrackModel/src/trackmodel/view/TrackModelUserInterface.java
+++ b/TrackModel/src/trackmodel/view/TrackModelUserInterface.java
@@ -1,29 +1,52 @@
 package trackmodel.view;
 
-import javafx.application.Application;
+import java.io.IOException;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
-
-import java.io.IOException;
+import trackmodel.controller.TrackModelController;
 
 public class TrackModelUserInterface {
 
-  /**
-   * Main class to called from the Main Menu.
-   * @param args necessary String array
-   */
-  public static void main(String[] args) {
+  private static TrackModelUserInterface instance = null;
+  private TrackModelController controller;
+  private Parent root;
+
+  private TrackModelUserInterface() {
+
+    FXMLLoader loader = new FXMLLoader(getClass().getResource("trackmodel.fxml"));
 
     try {
-      Parent root1 = (Parent) FXMLLoader.load(
-          TrackModelUserInterface.class.getResource("trackmodel.fxml"));
-      Stage stage = new Stage();
-      stage.setScene(new Scene(root1));
-      stage.show();
+      this.root = loader.load();
+      this.controller = loader.getController();
     } catch (IOException e) {
       System.out.println(e);
     }
+  }
+
+  /**
+   * This is the logic to maintain a single instance of a Track Model UI object.
+   * @return the single instance of the Track Model UI
+   */
+  public static TrackModelUserInterface getInstance() {
+    if (instance == null) {
+      instance = new TrackModelUserInterface();
+    }
+    return instance;
+  }
+
+  /**
+   * Called by Main Menu to load the window for the Track Model UI.
+   */
+  public void load() {
+
+    Stage stage = new Stage();
+    stage.setScene(new Scene(root));
+    stage.show();
+  }
+
+  public TrackModelController getController() {
+    return controller;
   }
 }

--- a/TrackModel/src/trackmodel/view/trackmodel.fxml
+++ b/TrackModel/src/trackmodel/view/trackmodel.fxml
@@ -15,7 +15,7 @@
 <?import javafx.scene.shape.Circle?>
 <?import javafx.scene.text.Font?>
 
-<SplitPane dividerPositions="0.3965744400527009" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="393.0" prefWidth="749.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="trackmodel.controller.Controller">
+<SplitPane dividerPositions="0.3965744400527009" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="393.0" prefWidth="749.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="trackmodel.controller.TrackModelController">
     <items>
         <AnchorPane prefHeight="391.0" prefWidth="195.0">
             <children>

--- a/TrainModel/src/trainmodel/TrainModelInterface.java
+++ b/TrainModel/src/trainmodel/TrainModelInterface.java
@@ -15,7 +15,7 @@ import utils.TrainModelEnums.TrackLineStatus;
 public interface TrainModelInterface {
 
   /**
-   * The following methods are getters/setters for data going to the Train Controller.
+   * The following methods are getters/setters for data going to the Train MovingBlockOverlayController.
    */
   //Getters
   double getCurrentSpeed();


### PR DESCRIPTION
## Description
This patch allows trains to automatically dispatch from the queue when the clock reaches their departure time. I also refactored the MBO && Track Model to allow them to be accessed via the Main Menu. This included turning the controller classes into singletons. There is now a central controller for each module with one instance (CTC, MBO, and TrackModel) that can be accessed via a getInstance() method. This should also be applied to the model classes, once they are created. Owner of modules with multiple instances will need to use another method, although refactored UserInterface classes should be very similar, if not the same.

## Changes
- MBO, CTC, && TrackModel now accessed via Main Menu buttons
- MBO, CTC, && TrackModel controllers now are singletons that can be accessed via a getInstance() method - see CTC for guidance on how to integrate module with Runner class
- Trains now automatically dispatched from queue

## Testing
Open the Runner class and click the appropriate button. Check console for errors.

## Additional Information
N/A
