### PR TITLE
Disabled forbidden UI components in Main Menu

### DIFF
--- a/CTC/src/ctc/controller/CentralTrafficControlController.java
+++ b/CTC/src/ctc/controller/CentralTrafficControlController.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javafx.application.Platform;
+import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
@@ -21,6 +22,8 @@ import javafx.scene.control.cell.TextFieldTableCell;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 import mainmenu.Clock;
+import traincontroller.model.TrainController;
+import trainmodel.model.TrainModel;
 
 public class CentralTrafficControlController {
 
@@ -548,6 +551,8 @@ public class CentralTrafficControlController {
       if (ctc.getTrainQueueTable().get(i).getName().equals(selected.getName())) {
         ctc.getTrainQueueTable().remove(i);
         ctc.getTrainList().remove(i);
+        TrainController.delete(selected.getName());
+        TrainModel.delete(selected.getName());
       }
     }
 

--- a/MainMenu/src/mainmenu/controller/MainMenuController.java
+++ b/MainMenu/src/mainmenu/controller/MainMenuController.java
@@ -4,6 +4,8 @@ import ctc.view.CentralTrafficControlUserInterface;
 
 import java.net.URL;
 import java.util.ResourceBundle;
+
+import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
@@ -104,13 +106,16 @@ public class MainMenuController implements Initializable {
   public void updateTrainControllerDropdown() {
     trainControllerChoiceBox.setItems(TrainController.getListOfTrains());
 
-    if (TrainController.getListOfTrains().size() == 1) {
+    if (TrainController.getListOfTrains().size() > 0) {
       trainControllerChoiceBox.setDisable(false);
       trainControllerButton.setDisable(false);
-    }
 
-    if (trainControllerChoiceBox.getSelectionModel().isEmpty()) {
-      trainControllerChoiceBox.setValue(TrainController.getListOfTrains().get(0));
+      if (trainControllerChoiceBox.getSelectionModel().isEmpty()) {
+        trainControllerChoiceBox.setValue(TrainController.getListOfTrains().get(0));
+      }
+    } else {
+      trainControllerButton.setDisable(true);
+      trainControllerChoiceBox.setDisable(true);
     }
   }
 
@@ -125,44 +130,22 @@ public class MainMenuController implements Initializable {
   }
 
   public void updateTrainModelDropdown() {
-    trainModelChoiceBox.setItems(TrainModel.getObservableListOfTrainModels());
+    ObservableList list = TrainModel.getObservableListOfTrainModels();
+    trainModelChoiceBox.setItems(list);
 
-    if (TrainModel.getObservableListOfTrainModels().size() == 1) {
+    if (TrainModel.getObservableListOfTrainModels().size() > 0) {
       trainModelChoiceBox.setDisable(false);
       trainModelButton.setDisable(false);
-    }
 
-    if (trainModelChoiceBox.getSelectionModel().isEmpty()) {
-      trainModelChoiceBox.setValue(TrainModel.getObservableListOfTrainModels().get(0));
+      if (trainModelChoiceBox.getSelectionModel().isEmpty()) {
+        trainModelChoiceBox.setValue(TrainModel.getObservableListOfTrainModels().get(0));
+      }
+    } else {
+      trainModelButton.setDisable(true);
+      trainModelChoiceBox.setDisable(true);
     }
   }
 
   @Override
   public void initialize(URL location, ResourceBundle resources) {}
-
-  public void run() {
-
-    updateInstanceComponents();
-  }
-
-  public void updateInstanceComponents() {
-
-    if (TrainModel.getObservableListOfTrainModels().size() == 0) {
-      trainModelButton.setDisable(true);
-      trainModelChoiceBox.setDisable(true);
-    } else {
-      trainModelButton.setDisable(false);
-      trainModelChoiceBox.setDisable(false);
-    }
-
-    if (TrainController.getListOfTrains().size() == 0) {
-      trainControllerButton.setDisable(true);
-      trainControllerChoiceBox.setDisable(true);
-    } else {
-      trainControllerButton.setDisable(false);
-      trainControllerChoiceBox.setDisable(false);
-    }
-
-    // TODO: disable the trackController components once theyre set up
-  }
 }

--- a/MainMenu/src/mainmenu/controller/MainMenuController.java
+++ b/MainMenu/src/mainmenu/controller/MainMenuController.java
@@ -7,6 +7,7 @@ import java.util.ResourceBundle;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
+import javafx.scene.control.Button;
 import javafx.scene.control.ChoiceBox;
 import mainmenu.model.MainMenuModel;
 import mbo.view.MovingBlockOverlayUserInterface;
@@ -22,11 +23,8 @@ import trainmodel.model.TrainModel;
  */
 public class MainMenuController implements Initializable {
 
-  private static int id = 0;
-
-  private MainMenuModel mmm = MainMenuModel.getInstance();
-
   private static MainMenuController instance;
+  private MainMenuModel mmm = MainMenuModel.getInstance();
 
   private CentralTrafficControlUserInterface ctcui =
       CentralTrafficControlUserInterface.getInstance();
@@ -37,15 +35,12 @@ public class MainMenuController implements Initializable {
   private TrackModelUserInterface tmui =
       TrackModelUserInterface.getInstance();
 
+  @FXML private Button trackControllerButton;
   @FXML private ChoiceBox<String> trackControllerChoiceBox;
+  @FXML private Button trainControllerButton;
   @FXML private ChoiceBox<String> trainControllerChoiceBox;
+  @FXML private Button trainModelButton;
   @FXML private ChoiceBox<String> trainModelChoiceBox;
-
-  @Override
-  public void initialize(URL location, ResourceBundle resources) {
-
-    // TODO: initialize lists here
-  }
 
   private MainMenuController() { }
 
@@ -108,6 +103,15 @@ public class MainMenuController implements Initializable {
 
   public void updateTrainControllerDropdown() {
     trainControllerChoiceBox.setItems(TrainController.getListOfTrains());
+
+    if (TrainController.getListOfTrains().size() == 1) {
+      trainControllerChoiceBox.setDisable(false);
+      trainControllerButton.setDisable(false);
+    }
+
+    if (trainControllerChoiceBox.getSelectionModel().isEmpty()) {
+      trainControllerChoiceBox.setValue(TrainController.getListOfTrains().get(0));
+    }
   }
 
   /**
@@ -122,5 +126,43 @@ public class MainMenuController implements Initializable {
 
   public void updateTrainModelDropdown() {
     trainModelChoiceBox.setItems(TrainModel.getObservableListOfTrainModels());
+
+    if (TrainModel.getObservableListOfTrainModels().size() == 1) {
+      trainModelChoiceBox.setDisable(false);
+      trainModelButton.setDisable(false);
+    }
+
+    if (trainModelChoiceBox.getSelectionModel().isEmpty()) {
+      trainModelChoiceBox.setValue(TrainModel.getObservableListOfTrainModels().get(0));
+    }
+  }
+
+  @Override
+  public void initialize(URL location, ResourceBundle resources) {}
+
+  public void run() {
+
+    updateInstanceComponents();
+  }
+
+  public void updateInstanceComponents() {
+
+    if (TrainModel.getObservableListOfTrainModels().size() == 0) {
+      trainModelButton.setDisable(true);
+      trainModelChoiceBox.setDisable(true);
+    } else {
+      trainModelButton.setDisable(false);
+      trainModelChoiceBox.setDisable(false);
+    }
+
+    if (TrainController.getListOfTrains().size() == 0) {
+      trainControllerButton.setDisable(true);
+      trainControllerChoiceBox.setDisable(true);
+    } else {
+      trainControllerButton.setDisable(false);
+      trainControllerChoiceBox.setDisable(false);
+    }
+
+    // TODO: disable the trackController components once theyre set up
   }
 }

--- a/MainMenu/src/mainmenu/view/Runner.java
+++ b/MainMenu/src/mainmenu/view/Runner.java
@@ -45,7 +45,6 @@ public class Runner extends Application {
                 if (ctc.isActive()) {
                   clk.tick();
                   ctcc.run();
-                  mmc.run();
                   TrainController.runAllInstances();
                 }
               }

--- a/MainMenu/src/mainmenu/view/Runner.java
+++ b/MainMenu/src/mainmenu/view/Runner.java
@@ -45,6 +45,7 @@ public class Runner extends Application {
                 if (ctc.isActive()) {
                   clk.tick();
                   ctcc.run();
+                  mmc.run();
                   TrainController.runAllInstances();
                 }
               }

--- a/MainMenu/src/mainmenu/view/mainmenuview.fxml
+++ b/MainMenu/src/mainmenu/view/mainmenuview.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane xmlns="http://javafx.com/javafx/8.0.65" xmlns:fx="http://javafx.com/fxml/1">
+<AnchorPane xmlns="http://javafx.com/javafx/9" xmlns:fx="http://javafx.com/fxml/1">
    <children>
       <VBox alignment="TOP_CENTER" layoutX="25.0" layoutY="38.0" spacing="20.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="25.0" AnchorPane.rightAnchor="25.0" AnchorPane.topAnchor="40.0">
          <children>
@@ -51,12 +51,12 @@
             </HBox>
             <HBox alignment="CENTER_LEFT" spacing="20.0">
                <children>
-                  <Button mnemonicParsing="false" onAction="#openTrainController" prefHeight="35.0" prefWidth="220.0" text="Train Controller">
+                  <Button fx:id="trainControllerButton" disable="true" mnemonicParsing="false" onAction="#openTrainController" prefHeight="35.0" prefWidth="220.0" text="Train Controller">
                      <font>
                         <Font size="18.0" />
                      </font>
                   </Button>
-                  <ChoiceBox fx:id="trainControllerChoiceBox" prefHeight="35.0" prefWidth="145.0" />
+                  <ChoiceBox fx:id="trainControllerChoiceBox" disable="true" prefHeight="35.0" prefWidth="145.0" />
                </children>
             </HBox>
             <HBox>
@@ -70,12 +70,12 @@
             </HBox>
             <HBox alignment="CENTER_LEFT" spacing="20.0">
                <children>
-                  <Button fx:id="trainModelButton" mnemonicParsing="false" onAction="#openTrainModel" prefHeight="35.0" prefWidth="220.0" text="Train Model">
+                  <Button fx:id="trainModelButton" disable="true" mnemonicParsing="false" onAction="#openTrainModel" prefHeight="35.0" prefWidth="220.0" text="Train Model">
                      <font>
                         <Font size="18.0" />
                      </font>
                   </Button>
-                  <ChoiceBox fx:id="trainModelChoiceBox" prefHeight="35.0" prefWidth="145.0" />
+                  <ChoiceBox fx:id="trainModelChoiceBox" disable="true" prefHeight="35.0" prefWidth="145.0" />
                </children>
             </HBox>
             <Label text="On-Track Development | 2018">

--- a/TrainController/src/traincontroller/model/TrainController.java
+++ b/TrainController/src/traincontroller/model/TrainController.java
@@ -254,7 +254,6 @@ public class TrainController implements TrainControllerInterface {
   }
 
   private void start() {
-    trainModel = new TrainModel(this, id.getValue(), line.getValue());
     running = true;
   }
 


### PR DESCRIPTION
## Description
When the there are no trains created, the buttons/dropdowns for the TrainModel  && TrainController are disabled. They become enabled when there is a train to be selected. The same will be done for the TrackController once that is integrated with the Main Menu.

## Changes
- disable UI components on Main Menu
- add run() to MainMenuController to check for trains every tick

## Testing
1. Open Main Menu
2. Check that Button && ChoiceBox for TrainModel && TrainController are disabled
3. Add train to queue in CTC
4. Check that the Button && ChoiceBox for TrainModel && TrainController are enabled and that the value of the ChoiceBox is set to the train name

## Additional Information
N/A
