### PR TITLE
CTC units corrected

### DIFF
--- a/CTC/src/ctc/controller/CentralTrafficControlController.java
+++ b/CTC/src/ctc/controller/CentralTrafficControlController.java
@@ -198,7 +198,7 @@ public class CentralTrafficControlController {
     dispatchAuthorityColumn.setCellValueFactory(
         new PropertyValueFactory<TrainTracker, String>("displayAuthority"));
     dispatchSpeedColumn.setCellValueFactory(
-        new PropertyValueFactory<TrainTracker, String>("speed"));
+        new PropertyValueFactory<TrainTracker, String>("displaySpeed"));
     dispatchPassengersColumn.setCellValueFactory(
         new PropertyValueFactory<TrainTracker, String>("passengers"));
 
@@ -1026,6 +1026,7 @@ public class CentralTrafficControlController {
 
       // get the signals
       float speed = Float.parseFloat(suggestedSpeedField.getText());
+      speed  = speed * (float)UnitConversions.MPH_TO_KPH;
       Authority authority = train.getAuthority();
 
       // check the new speed

--- a/CTC/src/ctc/model/TrainTracker.java
+++ b/CTC/src/ctc/model/TrainTracker.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.TimeZone;
 
 import mainmenu.Clock;
-import sun.tools.jconsole.Plotter;
 import trackctrl.model.TrackControllerLineManager;
 import trackmodel.model.Block;
 import trackmodel.model.Switch;

--- a/CTC/src/ctc/model/TrainTracker.java
+++ b/CTC/src/ctc/model/TrainTracker.java
@@ -7,12 +7,14 @@ import java.util.List;
 import java.util.TimeZone;
 
 import mainmenu.Clock;
+import sun.tools.jconsole.Plotter;
 import trackctrl.model.TrackControllerLineManager;
 import trackmodel.model.Block;
 import trackmodel.model.Switch;
 import trackmodel.model.Track;
 import traincontroller.model.TrainControllerFactory;
 import utils.general.Authority;
+import utils.unitconversion.UnitConversions;
 
 /**
  * This class is used to map the train instances to their routes.
@@ -190,8 +192,6 @@ public class TrainTracker {
       speed = location.getSpeedLimit();
     }
 
-
-
     // determine next authority
     String nextStationOnRoute = route.getNextStation();
     if (!isStopped) {
@@ -298,6 +298,10 @@ public class TrainTracker {
 
   public void setSpeed(float speed) {
     this.speed = speed;
+  }
+
+  public String getDisplaySpeed() {
+    return String.format("%.1f", (speed * (float) UnitConversions.KPH_TO_MPH));
   }
 
   public boolean isStopped() {


### PR DESCRIPTION
## Description
CTC now used correct units. This takes care of [BUG: CTC sets the train's set speed in km/hr and is not converted to MPH](https://trello.com/c/qnQXXcww). 

## Changes
- manual set speed is now converted to kph before being sent to TrainTracker
- correct speed is mph is displayed in the dispatch table

## Testing
Open CTC and ensure that units are in kph. The speed limit is usually around 43.5 mph (70 kph)

## Additional Information
The speed is still stored as kph in the TrainTracker - it is simply displayed as mph.
