### PR TITLE
Train now spans multiple blocks

### DIFF
--- a/MainMenu/src/mainmenu/Clock.java
+++ b/MainMenu/src/mainmenu/Clock.java
@@ -78,7 +78,7 @@ public class Clock implements ClockInterface {
    */
   public long getChangeInTime() {
     return timeSinceLastTick;
-    //return 40;
+//    return 20;
   }
 
   /**

--- a/TrainModel/src/trainmodel/model/TrainModel.java
+++ b/TrainModel/src/trainmodel/model/TrainModel.java
@@ -212,11 +212,12 @@ public class TrainModel implements TrainModelInterface {
 
     double changeInDist = changeInDist();
 
+    positionOfTail -= changeInDist;
+    positionOfHead += changeInDist;
+
     if (isEnteringBlock()) {
       positionOfHead -= currentBlock.getSize();
       updateCurrentBlock();
-    } else {
-      positionOfHead += changeInDist;
     }
 
     if (isLeavingBlock()) {
@@ -230,8 +231,6 @@ public class TrainModel implements TrainModelInterface {
         positionOfTail += previousBlock.getSize();
         trailingBlock = previousBlock;
       }
-    } else {
-      positionOfTail -= changeInDist;
     }
 
     if (currentBlock != null) {

--- a/TrainModel/src/trainmodel/model/TrainModel.java
+++ b/TrainModel/src/trainmodel/model/TrainModel.java
@@ -3,7 +3,6 @@ package trainmodel.model;
 import java.util.HashMap;
 import java.util.Random;
 
-import ctc.model.TrainTracker;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ObjectProperty;
@@ -213,7 +212,7 @@ public class TrainModel implements TrainModelInterface {
 
     double changeInDist = changeInDist();
 
-    if (isEnteringBlock(changeInDist)) {
+    if (isEnteringBlock()) {
       positionOfHead -= currentBlock.getSize();
       updateCurrentBlock();
     } else {
@@ -224,14 +223,11 @@ public class TrainModel implements TrainModelInterface {
 
       trailingBlock.setOccupied(false);
 
-//      trailingBlock = previousBlock.getSize() > TrainData.LENGTH_OF_TRAIN
-//          ? currentBlock : previousBlock;
-
-      if (previousBlock == trailingBlock) {
+      if (trailingBlock == previousBlock) {
         positionOfTail += currentBlock.getSize();
         trailingBlock = currentBlock;
-      } else {
-        positionOfTail += TrainData.LENGTH_OF_TRAIN - previousBlock.getSize();
+      } else if (trailingBlock != currentBlock) {
+        positionOfTail += previousBlock.getSize();
         trailingBlock = previousBlock;
       }
     } else {
@@ -241,12 +237,6 @@ public class TrainModel implements TrainModelInterface {
     if (currentBlock != null) {
       currentBlockName.set(currentBlock.getSection() + currentBlock.getNumber());
     }
-
-//    System.out.println("Location of head: " + positionOfHead);
-//    System.out.println("Location of tail: " + positionOfTail);
-//    System.out.println("Current block: " + currentBlock.getSection() + currentBlock.getNumber() + " : " + currentBlock.getSize());
-//    System.out.println("Previous block: " + previousBlock.getSection() + previousBlock.getNumber() + " : " + previousBlock.getSize());
-//    System.out.println("Trailing block: " + trailingBlock.getSection() + trailingBlock.getNumber() + " : " + trailingBlock.getSize());
   }
 
   private boolean isLeavingBlock() {
@@ -405,10 +395,9 @@ public class TrainModel implements TrainModelInterface {
 
   /**
    * Helper method to return true if a change in distance crosses block boarders.
-   * @param delta The distance the train moved.
    * @return true if train crosses block boarder, false otherwise.
    */
-  private boolean isEnteringBlock(double delta) {
+  private boolean isEnteringBlock() {
     return (positionOfHead > currentBlock.getSize());
   }
 

--- a/TrainModel/src/trainmodel/model/TrainModel.java
+++ b/TrainModel/src/trainmodel/model/TrainModel.java
@@ -3,6 +3,7 @@ package trainmodel.model;
 import java.util.HashMap;
 import java.util.Random;
 
+import ctc.model.TrainTracker;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ObjectProperty;
@@ -98,15 +99,15 @@ public class TrainModel implements TrainModelInterface {
   private boolean isMoving = false;
   private boolean isDispatched = false;
   private final int capacityOfTrain = TrainData.MAX_PASSENGERS * TrainData.NUMBER_OF_CARS;
-  private double positionInBlock = 0; //The number of meters from the border of the current block.
-  // Measured from the previous boarder to front of train.
+  private double positionOfHead = 0; //The number of meters from the border of the current block.
+  private double positionOfTail = 0;
 
   private Track activeTrack;
   private Block currentBlock; //where the head of the train is.
   private StringProperty currentBlockName = new SimpleStringProperty("Yard");
   private StringProperty activeTrackName = new SimpleStringProperty("");
   private Block previousBlock;
-  
+
   private Block trailingBlock; // used when train spans over 2 blocks. Maybe?
 
   private static HashMap<String, TrainModel> listOfTrainModels = new HashMap<>();
@@ -130,6 +131,8 @@ public class TrainModel implements TrainModelInterface {
     this.activeTrackName.set(line);
     this.currentBlock = activeTrack.getStartBlock();
     this.previousBlock = activeTrack.getBlock(-1);
+    this.trailingBlock = this.previousBlock;
+    this.positionOfTail = TrainData.LENGTH_OF_TRAIN;
   }
 
   /**
@@ -210,20 +213,44 @@ public class TrainModel implements TrainModelInterface {
 
     double changeInDist = changeInDist();
 
-    if (isCrossingBlock(changeInDist)) {
-      positionInBlock = 0;
+    if (isEnteringBlock(changeInDist)) {
+      positionOfHead -= currentBlock.getSize();
       updateCurrentBlock();
     } else {
-      positionInBlock = positionInBlock + changeInDist;
+      positionOfHead += changeInDist;
+    }
+
+    if (isLeavingBlock()) {
+
+      trailingBlock.setOccupied(false);
+
+//      trailingBlock = previousBlock.getSize() > TrainData.LENGTH_OF_TRAIN
+//          ? currentBlock : previousBlock;
+
+      if (previousBlock == trailingBlock) {
+        positionOfTail += currentBlock.getSize();
+        trailingBlock = currentBlock;
+      } else {
+        positionOfTail += TrainData.LENGTH_OF_TRAIN - previousBlock.getSize();
+        trailingBlock = previousBlock;
+      }
+    } else {
+      positionOfTail -= changeInDist;
     }
 
     if (currentBlock != null) {
       currentBlockName.set(currentBlock.getSection() + currentBlock.getNumber());
     }
 
-    //    System.out.println("Change in position: " + changeInDist);
-    //    System.out.println("Location in block: " + positionInBlock);
-    //    System.out.println("Current block: " + currentBlock.getSize());
+//    System.out.println("Location of head: " + positionOfHead);
+//    System.out.println("Location of tail: " + positionOfTail);
+//    System.out.println("Current block: " + currentBlock.getSection() + currentBlock.getNumber() + " : " + currentBlock.getSize());
+//    System.out.println("Previous block: " + previousBlock.getSection() + previousBlock.getNumber() + " : " + previousBlock.getSize());
+//    System.out.println("Trailing block: " + trailingBlock.getSection() + trailingBlock.getNumber() + " : " + trailingBlock.getSize());
+  }
+
+  private boolean isLeavingBlock() {
+    return positionOfTail <= 0;
   }
 
   /**
@@ -262,7 +289,6 @@ public class TrainModel implements TrainModelInterface {
     if (currentBlock != null) {
       currentBlock.setOccupied(true);
     }
-
   }
 
   /**
@@ -337,14 +363,7 @@ public class TrainModel implements TrainModelInterface {
       updatePosition();
       updateOccupancy();
       updateSpeedAuth();
-//      checkBrakes();
       changeTemperature();
-
-      //      System.out.println("Block: " + currentBlock.getSection() + currentBlock.getNumber());
-      //      System.out.println("Acceleration: " + acceleration);
-      //      System.out.println("Velocity: " + velocity.get());
-      //      System.out.println("Force: " + force);
-      //      System.out.println("Power: " + powerCommand.get());
     }
   }
 
@@ -386,12 +405,11 @@ public class TrainModel implements TrainModelInterface {
 
   /**
    * Helper method to return true if a change in distance crosses block boarders.
-   * @param distChange The distance the train moved.
+   * @param delta The distance the train moved.
    * @return true if train crosses block boarder, false otherwise.
    */
-  private boolean isCrossingBlock(double distChange) {
-    previousBlock.setOccupied(false);
-    return ((positionInBlock + distChange) > currentBlock.getSize());
+  private boolean isEnteringBlock(double delta) {
+    return (positionOfHead > currentBlock.getSize());
   }
 
   /**


### PR DESCRIPTION
## Description
Train now spans multiple blocks as it traverses the track. 

## Changes
- added a `trailingBlock` to the `TrainModel`
- entering `currentBlock` now sets the occupancy true and leaving `trailingBlock` sets the occupancy false
- fixed bug where `positionOfHead` is set to zero when it crosses into a new block, when it should take into account the small distance it already is into the block.

## Testing
Dispatch a train and open Track Model to view the occupied blocks. Ensure that the train is properly traversing blocks. You may want to set a the set speed to a lower speed to view the train as it traverses multiple blocks.

## Additional Information
I am confident the train is properly setting the occupancy. It properly spans all 3 blocks when crossing a block that is less than the length of the train (blocks 50 meters and under). Please check that this is working. Also, the train still acts wonky when the clock speed is high (usually, above 8 - 10). When testing, make sure the clock speed isn't throwing off the test, as this is a separate issue.

Also, keep in mind that the `previousBlock` is simply used to maintain the direction of movement, and as such the `trailingBlock` may be ahead of it, ie. at the `currentBlock`
