### PR TITLE
Small fixes to CTC and clock

### DIFF
--- a/CTC/src/ctc/controller/CentralTrafficControlController.java
+++ b/CTC/src/ctc/controller/CentralTrafficControlController.java
@@ -135,6 +135,17 @@ public class CentralTrafficControlController {
   }
 
   private void updateDisplays() {
+    TrainTracker train = dispatchTable.getSelectionModel().getSelectedItem();
+    if (train != null) {
+      if (train.isStopped()) {
+        trainStatus.setFill(Paint.valueOf("Red"));
+      } else {
+        trainStatus.setFill(Paint.valueOf("#24c51b"));
+      }
+    } else {
+      trainStatus.setFill(Paint.valueOf("Grey"));
+    }
+
     dispatchTable.refresh();
   }
 

--- a/CTC/src/ctc/controller/CentralTrafficControlController.java
+++ b/CTC/src/ctc/controller/CentralTrafficControlController.java
@@ -135,6 +135,8 @@ public class CentralTrafficControlController {
   }
 
   private void updateDisplays() {
+
+    // update train status light
     TrainTracker train = dispatchTable.getSelectionModel().getSelectedItem();
     if (train != null) {
       if (train.isStopped()) {
@@ -224,9 +226,11 @@ public class CentralTrafficControlController {
             setStyle("");
           } else {
             if (tracker.isStopped()) {
-              row.setStyle("-fx-selection-bar-non-focused: salmon;");
+              row.setStyle("-fx-selection-bar-non-focused: salmon;"
+                  + "-fx-selection-bar: salmon;");
             } else {
-              row.setStyle("-fx-selection-bar-non-focused: #cdee83;");
+              row.setStyle("-fx-selection-bar-non-focused: #cdee83;"
+                  + "-fx-selection-bar: #cdee83;");
             }
           }
         }
@@ -907,6 +911,12 @@ public class CentralTrafficControlController {
 
         // create train
         ctc.addTrain(train);
+
+        // automatically select the first item if one hasn't been selected
+        TrainTracker queued = trainQueueTable.getSelectionModel().getSelectedItem();
+        if (queued == null) {
+          trainQueueTable.getSelectionModel().selectFirst();
+        }
       } else {
 
         AlertWindow alert = new AlertWindow();
@@ -977,6 +987,8 @@ public class CentralTrafficControlController {
         if (ctc.getTrainQueueTable().size() == 0) {
           selectedScheduleTable.setItems(FXCollections.observableArrayList());
         }
+
+        dispatchTable.getSelectionModel().select(selected);
       }
     } else if (ctc.isActive()) {
 
@@ -1091,5 +1103,7 @@ public class CentralTrafficControlController {
     if (ctc.getTrainQueueTable().size() == 0) {
       selectedScheduleTable.setItems(FXCollections.observableArrayList());
     }
+
+    dispatchTable.getSelectionModel().select(train);
   }
 }

--- a/MainMenu/src/mainmenu/Clock.java
+++ b/MainMenu/src/mainmenu/Clock.java
@@ -86,7 +86,7 @@ public class Clock implements ClockInterface {
    * @param mult is the multiplier used for each clock tick
    */
   public void setMultiplier(int mult) {
-    if (mult > 0) {
+    if (mult > 0 && mult < 11) {
       multiplier = mult;
     }
   }


### PR DESCRIPTION
## Description
This PR includes some styling fixes to the CTC, as well as other small fixes.

## Changes
- clock multiplier is now capped at 10x
- the Train Status button in the CTC now shows green for a moving train and red for a stopped train
-  when an item is added to a list, it is automatically selected, fixing the annoying bug where the user had to select the train before dispatching a train
- trains in the dispatch table are now automatically colored when dispatched
- highlighted trains in the dispatch table no longer show up as dark blue and correspond to the color of the row

## Testing
Test the above features.

## Additional Information
N/A
