### PR TITLE
CTC now doesn't allow train schedule with only one stop

### DIFF
--- a/CTC/src/ctc/controller/CentralTrafficControlController.java
+++ b/CTC/src/ctc/controller/CentralTrafficControlController.java
@@ -832,14 +832,28 @@ public class CentralTrafficControlController {
 
       // create schedule
       Schedule schedule =  new Schedule(line);
+      int numberOfStops = 0;
       for (int i = 0; i < addScheduleTable.getItems().size(); i++) {
         schedule.addStop(new ScheduleRow(stopData.get(i), dwellData.get(i), ""));
+        if (stopData.get(i).compareTo("") != 0) {
+          numberOfStops++;
+        }
       }
 
       String name = trainNameField.getText();
       String departingTime = departingTimeField.getText();
 
-      if (!(name.compareTo("") == 0) && departingTime.length() == 8) {
+
+
+      if (numberOfStops == 1) {
+        AlertWindow alert = new AlertWindow();
+
+        alert.setTitle("Error Submitting");
+        alert.setHeader("Invalid Number Of Stops");
+        alert.setContent("Schedule needs to include more than one stop");
+
+        alert.show();
+      } else if (!(name.compareTo("") == 0) && departingTime.length() == 8) {
 
         TrainTracker train = new TrainTracker(name, departingTime, line, schedule);
         train.setLine(ctc.getLine()); // set the track that is current set


### PR DESCRIPTION
## Description
CTC won't create schedule with only one stops. This is because guests need to be able to be board and leave the train, requiring at least 2 stops.

## Changes
- error message to signal illegal schedule

## Testing
Try to make schedule with one stop and then two stops.

## Additional Information
N/A
