### PR TITLE
Fixed routing bug

### DIFF
--- a/CTC/src/ctc/controller/CentralTrafficControlController.java
+++ b/CTC/src/ctc/controller/CentralTrafficControlController.java
@@ -139,7 +139,7 @@ public class CentralTrafficControlController {
     // update train status light
     TrainTracker train = dispatchTable.getSelectionModel().getSelectedItem();
     if (train != null) {
-      if (train.isStopped()) {
+      if (train.isStopped() || train.isWaitingForAuthority()) {
         trainStatus.setFill(Paint.valueOf("Red"));
       } else {
         trainStatus.setFill(Paint.valueOf("#24c51b"));
@@ -225,7 +225,7 @@ public class CentralTrafficControlController {
           if (tracker == null) {
             setStyle("");
           } else {
-            if (tracker.isStopped()) {
+            if (tracker.isStopped() || tracker.isWaitingForAuthority()) {
               row.setStyle("-fx-selection-bar-non-focused: salmon;"
                   + "-fx-selection-bar: salmon;");
             } else {

--- a/CTC/src/ctc/controller/CentralTrafficControlController.java
+++ b/CTC/src/ctc/controller/CentralTrafficControlController.java
@@ -1056,7 +1056,7 @@ public class CentralTrafficControlController {
       Block location = train.getLocation();
 
       // make new route with the new authority
-      Route route = new Route(location, end, line, train);
+      Route route = train.getRoute().reroute(location, end);
       train.setRoute(route);
 
       // let the TrainTracker know that it has a new authority

--- a/CTC/src/ctc/controller/CentralTrafficControlController.java
+++ b/CTC/src/ctc/controller/CentralTrafficControlController.java
@@ -1050,7 +1050,9 @@ public class CentralTrafficControlController {
       // get block of of authority
       Track track = Track.getListOfTracks().get(line);
       String blockId = setAuthorityBlocks.getSelectionModel().getSelectedItem();
-      Block end = track.getBlock(Integer.parseInt(blockId.replaceAll("[\\D]", "")));
+
+      Block end = blockId.compareTo("Yard") == 0 ? track.getBlock(-1)
+          : track.getBlock(Integer.parseInt(blockId.replaceAll("[\\D]", "")));
       Block location = train.getLocation();
 
       // make new route with the new authority
@@ -1059,6 +1061,7 @@ public class CentralTrafficControlController {
 
       // let the TrainTracker know that it has a new authority
       train.setWaitingForAuthority(false);
+      train.setDone(false);
 
       // get new authority that is set inside of setRoute
       Authority authority = train.getAuthority();

--- a/CTC/src/ctc/model/Route.java
+++ b/CTC/src/ctc/model/Route.java
@@ -304,10 +304,13 @@ public class Route {
       Block current = line.getNextBlock(start.getNumber(), -1);
       traverse(current, line.getBlock(current.getPreviousBlock()), path);
     } else {
-      traverse(start, line.getBlock(start.getPreviousBlock()), path);
+//      traverse(line.getNextBlock(start.getNumber(), getPrevious().getNumber()), start,  path);
+      traverse(start, getPrevious(), path);
     }
 
     nextStationIndex = 0; // reset index
+    currentIndex = 0;
+
     path.add(end);
     this.route = path;
   }

--- a/CTC/src/ctc/model/Route.java
+++ b/CTC/src/ctc/model/Route.java
@@ -10,11 +10,11 @@ public class Route {
   private LinkedList<Block> route;
   private Block start;
   private Block end;
-  private int currentIndex;
   private Track line;
   private TrainTracker train;
   private String nextStation;
-  private int nextStationIndex;
+  private int currentIndex = 0;
+  private int nextStationIndex = 0;
 
   /**
    * Default constructor.
@@ -23,8 +23,6 @@ public class Route {
 
     this.line = Track.getListOfTracks().get(line);
     this.train = train;
-    this.nextStationIndex = 0;
-    this.currentIndex = 0;
     this.route = new LinkedList<>();
   }
 
@@ -37,9 +35,8 @@ public class Route {
 
     this.line = Track.getListOfTracks().get(line);
     this.train = train;
-    this.nextStationIndex = 0;
-    this.currentIndex = 0;
     createRoute(this.line.getStartBlock(), end);
+    this.nextStationIndex = 0;
   }
 
   /**
@@ -52,8 +49,6 @@ public class Route {
 
     this.line = Track.getListOfTracks().get(line);
     this.train = train;
-    this.nextStationIndex = 0;
-    this.currentIndex = 0;
     createRoute(start, end);
   }
 
@@ -313,11 +308,9 @@ public class Route {
       Block current = line.getNextBlock(start.getNumber(), -1);
       traverse(current, line.getBlock(current.getPreviousBlock()), path);
     } else {
-//      traverse(line.getNextBlock(start.getNumber(), getPrevious().getNumber()), start,  path);
       traverse(start, getPrevious(), path);
     }
 
-    nextStationIndex = 0; // reset index
     currentIndex = 0;
 
     path.add(end);

--- a/CTC/src/ctc/model/Route.java
+++ b/CTC/src/ctc/model/Route.java
@@ -57,6 +57,11 @@ public class Route {
     createRoute(start, end);
   }
 
+  public Route reroute(Block start, Block end) {
+    createRoute(start, end);
+    return this;
+  }
+
   Block getNext() {
     if (currentIndex < route.size() - 1) {
       return route.get(currentIndex + 1);
@@ -236,6 +241,10 @@ public class Route {
 
       // add next block - switch - to path
       path.add(next);
+
+      if (next == end) {
+        return;
+      }
 
       Block fork = line.getNextBlock2(next.getNumber(), current.getNumber());
       Block straight = line.getNextBlock(next.getNumber(), current.getNumber());

--- a/CTC/src/ctc/model/TrainTracker.java
+++ b/CTC/src/ctc/model/TrainTracker.java
@@ -368,7 +368,7 @@ public class TrainTracker {
     isWaitingForAuthority = waitingForAuthority;
   }
 
-  boolean isWaitingForAuthority() {
+  public boolean isWaitingForAuthority() {
     return isWaitingForAuthority;
   }
 }

--- a/CTC/src/ctc/model/TrainTracker.java
+++ b/CTC/src/ctc/model/TrainTracker.java
@@ -207,7 +207,8 @@ public class TrainTracker {
       authority.setAuthorityCommand(AuthorityCommand.SERVICE_BRAKE_STOP);
     }
 
-    authority.setBlocksLeft(((this.route.getSize() - 1) - this.route.getCurrentIndex()) > 31
+    authority.setBlocksLeft((((this.route.getSize() - 1) - this.route.getCurrentIndex()) > 31
+        || route.getLast().getNumber() == -1)
         ? 31 : (byte) ((this.route.getSize() - 1) - this.route.getCurrentIndex()));
 
     controller.sendTrackSignals(location.getNumber(), authority, speed);

--- a/CTC/src/ctc/model/TrainTracker.java
+++ b/CTC/src/ctc/model/TrainTracker.java
@@ -360,6 +360,10 @@ public class TrainTracker {
     return isDone;
   }
 
+  public void setDone(boolean isDone) {
+    this.isDone = isDone;
+  }
+
   public Route getRoute() {
     return route;
   }

--- a/TrainController/src/traincontroller/model/PowerCalculator.java
+++ b/TrainController/src/traincontroller/model/PowerCalculator.java
@@ -212,9 +212,15 @@ public class PowerCalculator {
     double kp = tc.getKp();
     double ki = tc.getKi();
     double integral;
-    double speedLimit = getSpeedLimit(tc, getSafeStopDistance(tc)) * 1000.0 / 3600.0;
+    double safeStoppingDistance = getSafeStopDistance(tc);
+    double speedLimit = getSpeedLimit(tc, safeStoppingDistance) * 1000.0 / 3600.0;
+    double endOfRoute = Double.MAX_VALUE;
+    if (tc.getBlocksLeft() < 10) {
+      endOfRoute = getDistanceLeft(tc);
+    }
 
-    if (currentSpeed > setSpeed || currentSpeed > speedLimit) {
+    if (currentSpeed > setSpeed || currentSpeed > speedLimit
+        || endOfRoute <= safeStoppingDistance + 10) {
       activateServiceBrake(tc);
       tc.setPowerCommand(0);
     } else {
@@ -263,6 +269,34 @@ public class PowerCalculator {
           track.getNextBlock2(currentBlock.getNumber(), currentBlock.getPreviousBlock()),
           currentBlock, remainingDistance));
       }
+    }
+    return min;
+  }
+
+  private static double getDistanceLeft(TrainController tc) {
+    double min = recursiveDistanceLeft(tc.getCurrentBlock(),
+        tc.getLastBlock(), tc.getBlocksLeft()) - tc.getDistanceIntoCurrentBlock();
+    return tc.getBlocksLeft() == 0 ? min : min + 10;
+  }
+
+  private static double recursiveDistanceLeft(Block currentBlock, Block lastBlock,
+                                            double blocksLeft) {
+    if (currentBlock == null) {
+      return Double.MAX_VALUE;
+    }
+    double min;
+    Track track = Track.getTrack(currentBlock.getLine());
+    if (blocksLeft <= 0) {
+      min = 0;
+    } else {
+      min = recursiveDistanceLeft(nextBlock(currentBlock, lastBlock, track),
+          currentBlock, blocksLeft - 1);
+      if (currentBlock.isSwitch()) {
+        min = Math.min(min, recursiveDistanceLeft(
+            track.getNextBlock2(currentBlock.getNumber(), currentBlock.getPreviousBlock()),
+            currentBlock, blocksLeft - 1));
+      }
+      min += currentBlock.getSize();
     }
     return min;
   }

--- a/TrainController/src/traincontroller/model/PowerCalculator.java
+++ b/TrainController/src/traincontroller/model/PowerCalculator.java
@@ -162,10 +162,10 @@ public class PowerCalculator {
     TrainModelInterface tm = tc.getTrainModel();
     double currentTemp = tm.getCurrentTemp();
     double setTemperature = tc.getSetTemperature();
-    if (currentTemp <= setTemperature) {
+    if (currentTemp <= setTemperature - 0.005) {
       tm.setHeaterStatus(OnOffStatus.ON);
       tm.setAcStatus(OnOffStatus.OFF);
-    } else if (currentTemp >= setTemperature) {
+    } else if (currentTemp >= setTemperature + 0.005) {
       tm.setAcStatus(OnOffStatus.ON);
       tm.setHeaterStatus(OnOffStatus.OFF);
     } else {

--- a/TrainController/src/traincontroller/model/PowerCalculator.java
+++ b/TrainController/src/traincontroller/model/PowerCalculator.java
@@ -250,7 +250,7 @@ public class PowerCalculator {
 
   private static double recursiveSpeedLimit(Block currentBlock, Block lastBlock,
                                             double remainingDistance) {
-    if (currentBlock == null) {
+    if (currentBlock == null || currentBlock.getNumber() == -1) {
       return 70;
     } else if (Double.isNaN(remainingDistance)) {
       return currentBlock.getSpeedLimit();
@@ -281,7 +281,7 @@ public class PowerCalculator {
 
   private static double recursiveDistanceLeft(Block currentBlock, Block lastBlock,
                                             double blocksLeft) {
-    if (currentBlock == null) {
+    if (currentBlock == null || currentBlock.getNumber() == -1) {
       return Double.MAX_VALUE;
     }
     double min;

--- a/TrainController/src/traincontroller/model/TrainController.java
+++ b/TrainController/src/traincontroller/model/TrainController.java
@@ -115,8 +115,8 @@ public class TrainController implements TrainControllerInterface {
     if (beacons.get(signal.getBlockId()) == null) {
       beacon = new Beacon(signal);
       beacons.put(signal.getBlockId(), beacon);
-      if (signal.getStationId() >= 0 &&
-          authority.getValue() == AuthorityCommand.STOP_AT_NEXT_STATION) {
+      if (signal.getStationId() >= 0
+          && authority.getValue() == AuthorityCommand.STOP_AT_NEXT_STATION) {
         distanceToStation = signal.getDistance();
         setCurrentStation(Track.getListOfTracks().get(getLine())
             .getStationList().get(signal.getStationId() - 1));

--- a/TrainController/src/traincontroller/model/TrainController.java
+++ b/TrainController/src/traincontroller/model/TrainController.java
@@ -115,7 +115,8 @@ public class TrainController implements TrainControllerInterface {
     if (beacons.get(signal.getBlockId()) == null) {
       beacon = new Beacon(signal);
       beacons.put(signal.getBlockId(), beacon);
-      if (signal.getStationId() >= 0 && authority.getValue() == AuthorityCommand.STOP_AT_NEXT_STATION) {
+      if (signal.getStationId() >= 0 &&
+          authority.getValue() == AuthorityCommand.STOP_AT_NEXT_STATION) {
         distanceToStation = signal.getDistance();
         setCurrentStation(Track.getListOfTracks().get(getLine())
             .getStationList().get(signal.getStationId() - 1));
@@ -139,25 +140,27 @@ public class TrainController implements TrainControllerInterface {
         setDriverSetSpeed(speed);
       }
     }
-    if (authority != null && getAuthority() != authority.getAuthorityCommand()) {
-      this.authority.set(authority.getAuthorityCommand());
+    if (authority != null) {
       this.blocksLeft = authority.getBlocksLeft();
-      switch (authority.getAuthorityCommand()) {
-        case SERVICE_BRAKE_STOP:
-          setMode(Mode.CTC_BRAKE);
-          break;
-        case STOP_AT_END_OF_ROUTE:
-        case SEND_POWER:
-          setMode(Mode.NORMAL);
-          break;
-        case STOP_AT_LAST_STATION:
-        case STOP_AT_NEXT_STATION:
-          setMode(Mode.STATION_BRAKE);
-          break;
-        case EMERGENCY_BRAKE_STOP:
-        default:
-          setMode(Mode.CTC_EMERGENCY_BRAKE);
-          break;
+      if (getAuthority() != authority.getAuthorityCommand()) {
+        this.authority.set(authority.getAuthorityCommand());
+        switch (authority.getAuthorityCommand()) {
+          case SERVICE_BRAKE_STOP:
+            setMode(Mode.CTC_BRAKE);
+            break;
+          case STOP_AT_END_OF_ROUTE:
+          case SEND_POWER:
+            setMode(Mode.NORMAL);
+            break;
+          case STOP_AT_LAST_STATION:
+          case STOP_AT_NEXT_STATION:
+            setMode(Mode.STATION_BRAKE);
+            break;
+          case EMERGENCY_BRAKE_STOP:
+          default:
+            setMode(Mode.CTC_EMERGENCY_BRAKE);
+            break;
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
Combined the PR on tcEndRoute with this. Fixed bug in Route, where re-routing the train to blocks before a switch would cause a stackoverflow error. 

## Changes
- train can now start and stop at mid-track authorities
- added `reroute()` to the Route
- changed the way trains are re-routed
- trains now display the correct next stop when authority is re-routed
- merged with tcEndRoute branch for testing

## Testing
Run train after the track with and without stops. Try to reroute the train the different blocks during this time. Record any errors. Please test extensively.

## Additional Information
The power command is still a little wonky, but the train stops at the right block.