### PR TITLE
Import schedule error handling

### DIFF
--- a/CTC/src/ctc/controller/CentralTrafficControlController.java
+++ b/CTC/src/ctc/controller/CentralTrafficControlController.java
@@ -746,10 +746,14 @@ public class CentralTrafficControlController {
         list.add(trainStop);
       }
 
-    } catch (FileNotFoundException e) {
-      e.printStackTrace();
-    } catch (IOException e) {
-      e.printStackTrace();
+    } catch (Exception e) {
+      AlertWindow alert = new AlertWindow();
+
+      alert.setTitle("File Error");
+      alert.setHeader("Issue Loading Schedule");
+      alert.setContent("Could not import the file. Please try again.");
+
+      alert.show();
     } finally {
 
       // set the image


### PR DESCRIPTION
## Description
Added a bit more error handling to the CTC.

## Changes
- importing invalid schedule now throws error message

## Testing
Try to load valid and invalid schedule (the schedule in ctc --> model --> green_schedule.csv)

## Additional Information
N/A
